### PR TITLE
Fix 'Mixed content blocking in Firefox' for http images

### DIFF
--- a/_posts/2021_02/2021-02-12-hello_worlds_part_1.md
+++ b/_posts/2021_02/2021-02-12-hello_worlds_part_1.md
@@ -74,7 +74,7 @@ States are identifiers in the `-machine-` block declared using the `$` symbol li
 
 Now we are on the map! This specification results in a model with `$Begin` as the start state:
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8Ld5BJC_CKghbgkQArOXLqTUqW8bmEgNafG5K0)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8Ld5BJC_CKghbgkQArOXLqTUqW8bmEgNafG5K0)
 
 To try this out yourself, copy the code above and paste into the left panel of the <a href='http://framepiler.frame-lang.org' target='_blank'>Framepiler</a> to see various kinds of output Frame notation can be converted into.
 

--- a/_posts/2021_02/2021-02-13-gotta_branch.md
+++ b/_posts/2021_02/2021-02-13-gotta_branch.md
@@ -200,7 +200,7 @@ The default behavior of Frame is to label transitions with the message that gene
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L71MgkMgXR2SmErehLa5Nrqx1aSiHH0D5hHJKb0sDJAnJ3I4qbqDgNWhG2000)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L71MgkMgXR2SmErehLa5Nrqx1aSiHH0D5hHJKb0sDJAnJ3I4qbqDgNWhG2000)
 
 However this leads to ambiguity with two or more transitions from the same event handler:
 
@@ -225,7 +225,7 @@ However this leads to ambiguity with two or more transitions from the same event
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8LGlEIKujA4ZFp5AgvQg5Y8KMbgKXSjyISOWW_MYjMGLVN3g692yu2YKCqMYceAHiQcLXdvXKNf2QNG3Ye2i56ubBfa9gN0dGV0000)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8LGlEIKujA4ZFp5AgvQg5Y8KMbgKXSjyISOWW_MYjMGLVN3g692yu2YKCqMYceAHiQcLXdvXKNf2QNG3Ye2i56ubBfa9gN0dGV0000)
 
 Transition labels provide clarity as to which transition is which:
 
@@ -250,7 +250,7 @@ Transition labels provide clarity as to which transition is which:
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8LGlEIKujA4ZFp5AgvQg5Y8KMbgKXSjyISOWW_MYjMGLVN3g692yu2YKCqMYcKWAYq_7nKMQWvLY0PXRpy4h0oBeVKl1IWQm00)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8LGlEIKujA4ZFp5AgvQg5Y8KMbgKXSjyISOWW_MYjMGLVN3g692yu2YKCqMYcKWAYq_7nKMQWvLY0PXRpy4h0oBeVKl1IWQm00)
 
 
 ## Conclusion

--- a/_posts/2021_02/2021-02-13-hello_worlds_part_3.md
+++ b/_posts/2021_02/2021-02-13-hello_worlds_part_3.md
@@ -133,7 +133,7 @@ Here is the `C#` generated from this system definition:
 
 And the equivalent UML statechart:
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8Ld5BJC_CKghbgeVpm_ABipBnq917Nl1GmBrehLa5NrmwYWmjCWlXm7LOAQig6HYRMTdOGcWig0L84CWIkmCO6gi0XDIy5w180)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8Ld5BJC_CKghbgeVpm_ABipBnq917Nl1GmBrehLa5NrmwYWmjCWlXm7LOAQig6HYRMTdOGcWig0L84CWIkmCO6gi0XDIy5w180)
 
 ## Hierarchical State Machines (HSMs)
 
@@ -141,7 +141,7 @@ The pinnacle of Statechart mods to the standard state machine is the idea of fac
 
 UML implements this concept visually. Here we see `$A` and `$B` have identical transitions to `$C` when responding to `|e|`:
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L71MgkMgXR2SajZEOpUMeeAjh1-HOAQWf6ngPMAT2A2ud7E8EgNafGCC1)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L71MgkMgXR2SajZEOpUMeeAjh1-HOAQWf6ngPMAT2A2ud7E8EgNafGCC1)
 
 In Frame notation that system looks like this:
 
@@ -180,7 +180,7 @@ As we can see, there is redundant behavior between states `$A` and `$B`.  **Hier
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8Ld1MgkMgXx834ejIy4g200X10X1oXl5eaCIUO650Z5rIFhguTq2Wh1JLbGoCJwrG8nUMGcfS2j0e0)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8Ld1MgkMgXx834ejIy4g200X10X1oXl5eaCIUO650Z5rIFhguTq2Wh1JLbGoCJwrG8nUMGcfS2j0e0)
 
 Thanks to the approach Frame takes with implementing state machines, the mechanism for coding HSM functionality is trivial:
 
@@ -328,7 +328,7 @@ $End
 
 Here is the Framepiler generated UML documentation for the `#FinalWorld`:
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8Ld5BJC_CKghbgeNoNrBJ4qfmIe8W24434mlEBiZFpqg5YjKWoGQd59KWoS5DSyrB0PaPhnIhewjf1RE42ao0-t4Gh1JLbGoCJQpix2Cq5bG0fWXgEK5IIcPmDLGQLWfk5GndKCo1b82V1bTZOG1KufEQb0CC20000)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8Ld5BJC_CKghbgeNoNrBJ4qfmIe8W24434mlEBiZFpqg5YjKWoGQd59KWoS5DSyrB0PaPhnIhewjf1RE42ao0-t4Gh1JLbGoCJQpix2Cq5bG0fWXgEK5IIcPmDLGQLWfk5GndKCo1b82V1bTZOG1KufEQb0CC20000)
 
 
 And at last, here is the final `C#` output and its running code (with a hand coded `print()` action):

--- a/_posts/2021_02/2021-02-14-history_of_states.md
+++ b/_posts/2021_02/2021-02-14-history_of_states.md
@@ -32,7 +32,7 @@ State machines are an inherently limited kind of system in that they have no mem
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L71MgkMgXR2SajZEOxQYWgsi7P5ifg2aR6fbOf-UNv3j3c5nEUEGSKlDIW7O00000)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L71MgkMgXR2SajZEOxQYWgsi7P5ifg2aR6fbOf-UNv3j3c5nEUEGSKlDIW7O00000)
 
 Here we see that `$C` has no way to know what state preceded it. To solve this problem for a <i>pure</i> state machine we would have to do something like this:
 
@@ -56,7 +56,7 @@ Here we see that `$C` has no way to know what state preceded it. To solve this p
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L71MgkMgXR2SajdCYCYS9p75KqDMr0ybOAQWf6ngPMAVdb-GxGvXSJX399AoIpebWMKUuP55gIMbH7ams2IphX5tM8JKl1UXU0000)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L71MgkMgXR2SajdCYCYS9p75KqDMr0ybOAQWf6ngPMAVdb-GxGvXSJX399AoIpebWMKUuP55gIMbH7ams2IphX5tM8JKl1UXU0000)
 
 `$Ca` and `$Cb` would be identical except for the response to the `|return|` message. This is obviously inefficient.
 
@@ -96,7 +96,7 @@ Let's see how these are used:
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuU82iafI5HmLghbgeMmd9BOpcEseeAjh1sHRAQYeH6l7SZcXyPt1_6WFhLY8a6uibqDgNWhGV000)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuU82iafI5HmLghbgeMmd9BOpcEseeAjh1sHRAQYeH6l7SZcXyPt1_6WFhLY8a6uibqDgNWhGV000)
 
 What we see above is that the state stack push token precedes a transition to a new state:
 
@@ -172,7 +172,7 @@ while the state stack pop operator produces the state to be transitioned into:
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuU82iafI5S8JCqioyz8LghbgeIAEI6md9BOpc1sj5QkWgsi7qyS5fK5YG9rM2chAXaOcrkdv9VcE42QA2YSK5KvG5Ou4vPo1SYegqTgnN4vuR792K-iCvaTxQCL2X7HZkHnIyrB0lkS20000)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuU82iafI5S8JCqioyz8LghbgeIAEI6md9BOpc1sj5QkWgsi7qyS5fK5YG9rM2chAXaOcrkdv9VcE42QA2YSK5KvG5Ou4vPo1SYegqTgnN4vuR792K-iCvaTxQCL2X7HZkHnIyrB0lkS20000)
 
  <iframe width="100%" height="475" src="https://dotnetfiddle.net/Widget/aofLnO" frameborder="0"></iframe>
 
@@ -221,7 +221,7 @@ while the state stack pop operator produces the state to be transitioned into:
 
 We can see that the duplicated `|gotoC|` event handler is now moved into `$AB` and both `$A` and `$B` inherit behavior from it.
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuU82iafI5S8JCqioyz8LghbgeIAEJa2E0X10kL1UBPAO4qmChiaPR42qLgo2hguTp50kA0qMSrImKb1JDZGoiKxFBybtX31HL3YXg722gd348-U4nsH7YAGpK5959LexbiiPp8_sq8g52Ed6SZcavgM0mW80)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuU82iafI5S8JCqioyz8LghbgeIAEJa2E0X10kL1UBPAO4qmChiaPR42qLgo2hguTp50kA0qMSrImKb1JDZGoiKxFBybtX31HL3YXg722gd348-U4nsH7YAGpK5959LexbiiPp8_sq8g52Ed6SZcavgM0mW80)
 
 Below we can see  that the system reports out it is now transitioning from `$AB` rather than from the individual states:
 

--- a/_posts/2021_03/2021-03-21-what_is_frame.md
+++ b/_posts/2021_03/2021-03-21-what_is_frame.md
@@ -36,7 +36,7 @@ The true power of Frame, however, is realized by the ability to generate both do
 
 `UML`
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L_DFI5AgvQc6yF30dMYjMGLVN3YJ91SGWDaZAIa5DsT38nBgaj2ZFFm_2vWAAGvMYo0FvK0KEgNafGFi0)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L_DFI5AgvQc6yF30dMYjMGLVN3YJ91SGWDaZAIa5DsT38nBgaj2ZFFm_2vWAAGvMYo0FvK0KEgNafGFi0)
 
 `C#`
 {% highlight csharp %}

--- a/_tabs/notation.md
+++ b/_tabs/notation.md
@@ -339,7 +339,7 @@ The Machine Block houses the system state machine and defines the behavior of th
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8Ld5BJC_CKghbgkQArOXLqTUqW8bmEgNafG5K0)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8Ld5BJC_CKghbgkQArOXLqTUqW8bmEgNafG5K0)
 
 ### States
 
@@ -740,7 +740,7 @@ A simple filter system is a good example of when changing state is more appropri
 
 Frame notates a state change `->>` visually using a dashed line:
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuUBY0Z9BKXMSS_ABKrCKghbgeGB-1QbvO6wqLgo2hguTL0KNLA5kT4fYSKPgIYnG1gpKIa5DsT38n3eVo86mk43Y28Lm8-1Aaq5Sg5g7rBmKe7i0)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuUBY0Z9BKXMSS_ABKrCKghbgeGB-1QbvO6wqLgo2hguTL0KNLA5kT4fYSKPgIYnG1gpKIa5DsT38n3eVo86mk43Y28Lm8-1Aaq5Sg5g7rBmKe7i0)
 
 The implementation of the state change mechanism consists of the addition of the `_changeState_()` method that only updates the `_state_` variable (no enter/exit events) as well as its use in the event handlers:
 
@@ -1008,7 +1008,7 @@ The default behavior of Frame is to label transitions with the message that gene
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L71MgkMgXR2SmErehLa5Nrqx1aSiHH0D5hHJKb0sDJAnJ3I4qbqDgNWhG2000)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8L71MgkMgXR2SmErehLa5Nrqx1aSiHH0D5hHJKb0sDJAnJ3I4qbqDgNWhG2000)
 
 However this leads to ambiguity with two or more transitions from the same event handler:
 
@@ -1033,7 +1033,7 @@ However this leads to ambiguity with two or more transitions from the same event
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8LGlEIKujA4ZFp5AgvQg5Y8KMbgKXSjyISOWW_MYjMGLVN3g692yu2YKCqMYceAHiQcLXdvXKNf2QNG3Ye2i56ubBfa9gN0dGV0000)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8LGlEIKujA4ZFp5AgvQg5Y8KMbgKXSjyISOWW_MYjMGLVN3g692yu2YKCqMYceAHiQcLXdvXKNf2QNG3Ye2i56ubBfa9gN0dGV0000)
 
 Transition labels provide clarity as to which transition is which:
 
@@ -1058,7 +1058,7 @@ Transition labels provide clarity as to which transition is which:
 ##
 ```
 
-![](http://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8LGlEIKujA4ZFp5AgvQg5Y8KMbgKXSjyISOWW_MYjMGLVN3g692yu2YKCqMYcKWAYq_7nKMQWvLY0PXRpy4h0oBeVKl1IWQm00)
+![](https://www.plantuml.com/plantuml/png/SoWkIImgAStDuG8oIb8LGlEIKujA4ZFp5AgvQg5Y8KMbgKXSjyISOWW_MYjMGLVN3g692yu2YKCqMYcKWAYq_7nKMQWvLY0PXRpy4h0oBeVKl1IWQm00)
 
 
 


### PR DESCRIPTION
At `https` site https://frame-lang.org/ Firefox not show images from `http` [1]. This pull request is fixing this - image source from `http://www.plantuml.com` to `https://www.plantuml.com`

[1] - https://support.mozilla.org/en-US/kb/mixed-content-blocking-firefox